### PR TITLE
Draw the background color seperately instead of drawing each grass tile individually

### DIFF
--- a/index.js
+++ b/index.js
@@ -568,13 +568,15 @@ window.onload = function () {
 
   function render () {
     let mt = Maps.tile
-    ctx.clearRect(0, 0, canvas.width, canvas.height)
+    ctx.fillStyle = '#0fa'
+    ctx.fillRect(0, 0, canvas.width, canvas.height)
 
     for (let i in Game.map.tiles) {
       let tile = Game.map.tiles[i]
       let index = parseInt(i)
       let y = Math.floor(index / Maps.width)
       let x = Math.floor(index % Maps.height)
+      var draw_tile = true
 
       if (tile === 1) {
         ctx.fillStyle = '#fdd'
@@ -583,10 +585,12 @@ window.onload = function () {
       } else if (tile === 3) {
         ctx.fillStyle = '#f3a'
       } else {
-        ctx.fillStyle = '#0fa'
+        draw_tile = false
       }
 
-      ctx.fillRect(x * mt, y * mt, mt, mt)
+      if(draw_tile) {
+        ctx.fillRect(x * mt, y * mt, mt, mt)
+      }
     }
 /*
     for (let i in Game.map.pathgen) {


### PR DESCRIPTION
Currently, the green background is rendered in small tiles, each drawn individually.  It is possible to draw the backdrop a single rectangle, thus reducing the work required to render each frame.  