### PR TITLE
[Feature Proposal] Ability to sell towers

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,8 @@ window.onload = function () {
     pace: 1,
     wave: 0,
     waveTimer: 0,
-    tower: 'simple'
+    tower: 'simple',
+    sellRatio: .8
   }
 
   /**
@@ -533,6 +534,16 @@ window.onload = function () {
     }, tower))
   }
 
+  function sellTower (x, y) {
+    var tower = getTowerAt(x, y)
+    if(tower) {
+      Game.money += tower.cost * Game.sellRatio
+      return Game.towers.splice(Game.towers.indexOf(tower), 1)
+    }else{
+      return null
+    }
+  }
+
   function update (dt) {
     fpsCount++
     fpsCount %= 20
@@ -728,6 +739,13 @@ window.onload = function () {
     }
 
     clickBtn()
+  })
+  
+  canvas.addEventListener('contextmenu', (e) => {
+    if (Game.state === 2 && mX < Maps.width && mY < Maps.height &&
+      sellTower(mX, mY)) {
+      e.preventDefault()
+    }
   })
 
   canvas.addEventListener('mousemove', (e) => {


### PR DESCRIPTION
Currently a placed tower is permanent, and cannot be moved or replaced by a better tower.  This causes issues when a player is adding advanced towers to their defense, as many ideal spots are already occupied by basic towers they had to place in earlier levels.  I suggest adding the ability to sell towers using a right click, for an adjustable fraction of the buy price.  This would enable the player to rearrange their defense at a cost.  