### PR TITLE
Fix enemy alignment

### DIFF
--- a/index.js
+++ b/index.js
@@ -1035,9 +1035,9 @@ window.onload = function () {
     for (let i in Game.enemies) {
       let margin = .25 //A ratio of the width of a tile.  .25 margins with 32 px tiles leave a 8 px margin on all sides, with the body being 16px x 16px
       let enemy = Game.enemies[i]
-      let rx = (enemy.x + mt) + mt * margin
-      let ry = (enemy.y * mt) + mt * margin
-      let w = mt - (mt * margin * 2)
+      let rx = (enemy.x + margin) * mt
+      let ry = (enemy.y + margin) * mt
+      let w = mt * (1 - margin * 2)
       ctx.fillStyle = enemy.icon
       ctx.fillRect(rx, ry, w, w)
 

--- a/index.js
+++ b/index.js
@@ -1033,11 +1033,13 @@ window.onload = function () {
 
     // Draw enemies
     for (let i in Game.enemies) {
+      let margin = .25 //A ratio of the width of a tile.  .25 margins with 32 px tiles leave a 8 px margin on all sides, with the body being 16px x 16px
       let enemy = Game.enemies[i]
-      let rx = (enemy.x * mt) + mt / 8
-      let ry = (enemy.y * mt) + mt / 8
+      let rx = (enemy.x + mt) + mt * margin
+      let ry = (enemy.y * mt) + mt * margin
+      let w = mt - (mt * margin * 2)
       ctx.fillStyle = enemy.icon
-      ctx.fillRect(rx, ry, 16, 16)
+      ctx.fillRect(rx, ry, w, w)
 
       // health bars
       let hx = rx - 6


### PR DESCRIPTION
This re-implements some of the code responsible for rendering enemies using a margin system.  This not only fixes the alignment of enemies in the path, but allows variably sized enemies and allows enemies to scale with map size (`Map.tile`).  A margin of .25 (currently set) leaves the width of the enemies alone, but properly aligns them on the path.